### PR TITLE
[skip ci] Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-* @yorinasub17 @robmorgan
+* @yorinasub17
+# Team: @bwhaley @robmorgan


### PR DESCRIPTION
We recently adopted a new team structure in. One of the things we need to do is update the `CODEOWNERS` file for each of the repos we own. Since I want to reduce noise, I am taking the approach where I will be the sole owner for the repos I lead (so that I get notified and assigned), but have others in the team in the file as a comment so that I know who I can solicit for help should it get overwhelming.